### PR TITLE
feat: add support for socks proxies

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,7 @@ module.exports = {
   , DEFAULT: 'default'
   }
 , PROTOCOL_RE: /^https?:\/\//
+, PROTOCOL_SOCKS_PROXY_RE: /^socks:\/\//
 , REQUEST_WITH_CREDENTIALS: false
 , TAGS_RE: /\s*,\s*/
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,6 +9,7 @@ const Agent = require('agentkeepalive')
 const axios = require('axios')
 const stringify = require('json-stringify-safe')
 const HttpsProxyAgent = require('https-proxy-agent')
+const SocksProxyAgent = require('socks-proxy-agent')
 const constants = require('./constants.js')
 const {checkStringParam, isValidTimestamp, has} = require('./validators/index.js')
 const backoffWithJitter = require('./backoff-with-jitter.js')
@@ -334,13 +335,17 @@ class Logger extends EventEmitter {
       : new Agent(constants.AGENT_SETTING)
 
     if (has(options, 'proxy')) {
-      if (typeof options.proxy !== 'string'
-        || !constants.PROTOCOL_RE.test(options.proxy)) {
+      if (typeof options.proxy === 'string'
+        && constants.PROTOCOL_RE.test(options.proxy)) {
+        agent = new HttpsProxyAgent(options.proxy)
+      } else if (typeof options.proxy === 'string'
+        && constants.PROTOCOL_SOCKS_PROXY_RE.test(options.proxy)) {
+        agent = new SocksProxyAgent(options.proxy)
+      } else {
         const err = new TypeError('proxy value must be a full http or https URL')
         err.meta = {got: options.proxy}
         throw err
       }
-      agent = new HttpsProxyAgent(options.proxy)
     }
 
     this[kUserAgentHeader] = `${constants.USER_AGENT}${transportedBy}`

--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
     "agentkeepalive": "^4.1.3",
     "axios": "^0.21.1",
     "https-proxy-agent": "^5.0.0",
-    "json-stringify-safe": "^5.0.1"
+    "json-stringify-safe": "^5.0.1",
+    "socks-proxy-agent": "^5.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",


### PR DESCRIPTION
Adding SocksProxyAgent as an alternative proxy option to run logdna
agent where internet needs to be accessed over a socks proxy. Currently
only supports passwordless socks proxy.